### PR TITLE
feat: post と tagの情報を supabase にインサートする関数

### DIFF
--- a/src/utils/insertPost.ts
+++ b/src/utils/insertPost.ts
@@ -1,0 +1,21 @@
+import { supabase } from './supabase/client';
+import type { Tables, TablesInsert } from '@/types/supabase';
+
+const insertPost = async (
+  table: Omit<TablesInsert<'post'>, 'id' | 'created_at' | 'deleted_at'>,
+  tags: string[],
+): Promise<Tables<'post'> | undefined> => {
+  const { data, error: postError } = await supabase.from('post').insert(table).select('*');
+  if (postError !== null) {
+    return undefined;
+  }
+
+  const { error: tagError } = await supabase.from('post_tag').insert(tags.map((tag) => ({ post_id: data[0].id, tag })));
+  if (tagError !== null) {
+    return undefined;
+  }
+
+  return data[0];
+};
+
+export default insertPost;

--- a/src/utils/insertPost.ts
+++ b/src/utils/insertPost.ts
@@ -6,7 +6,7 @@ const insertPost = async (
   tags: string[],
 ): Promise<Tables<'post'> | undefined> => {
   const { data, error: postError } = await supabase.from('post').insert(table).select('*');
-  if (postError !== null) {
+  if (postError !== null || data.length === 0) {
     return undefined;
   }
 


### PR DESCRIPTION
Closes <!-- issue の URL を貼り付けてください (https://github.com/SystemEngineeringTeam/project-exercises-kuso/issues/10) -->

## 説明

post と tag の情報を受け取って supabase に追加する関数を実装した

## 現在の動作 (更新前)

なし

## 新しい動作 (更新後)

```ts
const insertPost = async (
  table: Omit<TablesInsert<'post'>, 'id' | 'created_at' | 'deleted_at'>,
  tags: string[],
): Promise<Tables<'post'> | undefined>
```

post の情報を含んだ `Omit<TablesInsert<'post'>, 'id' | 'created_at' | 'deleted_at'>` とタグの文字列を含んだ `string[]` を受け取り、インサートに成功すればタグをのぞいた post のデータを、失敗すれば undefined を返す

## 追加情報

<!-- その他の情報があれば追加してください -->
