### PR TITLE
認証回避策を用意

### DIFF
--- a/src/app/(use-header)/layout.tsx
+++ b/src/app/(use-header)/layout.tsx
@@ -1,5 +1,5 @@
 import Header from '../_components/Header';
-// import LoginProvider from '../_components/LoginProvider';
+import LoginProvider from '../_components/LoginProvider';
 
 export default function RootLayout({
   children,
@@ -9,9 +9,9 @@ export default function RootLayout({
   return (
     <>
       <Header />
-      {/* <LoginProvider> */}
-      <main>{children}</main>
-      {/* </LoginProvider> */}
+      <LoginProvider>
+        <main>{children}</main>
+      </LoginProvider>
     </>
   );
 }

--- a/src/app/_components/LoginProvider/index.tsx
+++ b/src/app/_components/LoginProvider/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAtomValue, useSetAtom } from 'jotai';
-import { type ChangeEvent, type FormEvent, type ReactElement, useState } from 'react';
+import { type ChangeEvent, type FormEvent, type ReactElement, useState, useSyncExternalStore } from 'react';
 import styles from './index.module.scss';
 import { authAtom } from '@/stores/authAtom';
 import { supabase } from '@/utils/supabase/client';
@@ -10,11 +10,23 @@ interface Props {
   children: ReactElement;
 }
 
+const subscribe = (callback: () => void) => {
+  window.addEventListener('storage', callback);
+  return () => {
+    window.removeEventListener('storage', callback);
+  };
+};
+
 export default function LoginProvider({ children }: Props) {
   const auth = useAtomValue(authAtom);
+  const unauthorized = useSyncExternalStore(
+    subscribe,
+    () => localStorage.getItem('unauth') === 'true',
+    () => null,
+  );
 
-  if (auth === undefined) return <LoginPage />;
-  return children;
+  if (auth !== undefined || unauthorized === true) return children;
+  return <LoginPage />;
 }
 
 function LoginPage() {


### PR DESCRIPTION
Closes https://github.com/SystemEngineeringTeam/project-exercises-kuso/issues/54

## 説明

ローカルストレージで `unauth` に `true` を指定することでログインを飛ばせます.
※uid等を使う処理がある場合はちゃんとログインしましょう

## 現在の動作 (更新前)

<!-- 変更している現在の動作について説明してください -->

## 新しい動作 (更新後)

<!-- この PR によって追加される動作または変更について説明してください -->

## 追加情報

<!-- その他の情報があれば追加してください -->
