### PR TITLE
feat: crazy_scoreをDBに保存する関数の実装

### DIFF
--- a/src/utils/insertCrazyScore.ts
+++ b/src/utils/insertCrazyScore.ts
@@ -1,0 +1,16 @@
+import { supabase } from './supabase/client';
+import type { Tables, TablesInsert } from '@/types/supabase';
+
+const insertCrazyScore = async (
+  table: Omit<TablesInsert<'crazy_score'>, 'id' | 'created_at' | 'deleted_at'>,
+): Promise<Tables<'crazy_score'> | undefined> => {
+  const { data } = await supabase.from('crazy_score').upsert(table).select('*');
+
+  if (data === null) {
+    throw new Error('Error inserting data');
+  }
+
+  return data[0];
+};
+
+export default insertCrazyScore;

--- a/src/utils/upsertCrazyScore.ts
+++ b/src/utils/upsertCrazyScore.ts
@@ -4,10 +4,16 @@ import type { Tables, TablesInsert } from '@/types/supabase';
 const upsertCrazyScore = async (
   table: Omit<TablesInsert<'crazy_score'>, 'id' | 'created_at' | 'deleted_at'>,
 ): Promise<Tables<'crazy_score'> | undefined> => {
-  const { data } = await supabase.from('crazy_score').upsert(table).select('*');
+  const { data, error } = await supabase.from('crazy_score').upsert(table).select('*');
 
+  if (error !== null) {
+    throw new Error(error.message);
+  }
   if (data === null) {
-    throw new Error('Error inserting data');
+    throw new Error('Error return data is null');
+  }
+  if (data.length === 0) {
+    throw new Error('Error return data length is 0');
   }
 
   return data[0];

--- a/src/utils/upsertCrazyScore.ts
+++ b/src/utils/upsertCrazyScore.ts
@@ -1,7 +1,7 @@
 import { supabase } from './supabase/client';
 import type { Tables, TablesInsert } from '@/types/supabase';
 
-const insertCrazyScore = async (
+const upsertCrazyScore = async (
   table: Omit<TablesInsert<'crazy_score'>, 'id' | 'created_at' | 'deleted_at'>,
 ): Promise<Tables<'crazy_score'> | undefined> => {
   const { data } = await supabase.from('crazy_score').upsert(table).select('*');
@@ -13,4 +13,4 @@ const insertCrazyScore = async (
   return data[0];
 };
 
-export default insertCrazyScore;
+export default upsertCrazyScore;


### PR DESCRIPTION
Closes https://github.com/SystemEngineeringTeam/project-exercises-kuso/issues/47

## 説明

crazy_scoreをDBに保存するように

## 現在の動作 (更新前)

なし

## 新しい動作 (更新後)
```ts
const insertCrazyScore = async (
  table: Omit<TablesInsert<'crazy_score'>, 'id' | 'created_at' | 'deleted_at'>,
): Promise<Tables<'crazy_score'> | undefined> => {
  const { data } = await supabase.from('crazy_score').upsert(table).select('*');
```

Omit<TablesInsert<'crazy_score'>, 'id' | 'created_at' | 'deleted_at'> を受け取って、挿入後のPromise<Tables<'crazy_score'>>を返す

## 追加情報

<!-- その他の情報があれば追加してください -->
