### PR TITLE
fix: コードの表示を額縁風に

### DIFF
--- a/src/app/(use-header)/codes/_components/view/Page/Card.module.scss
+++ b/src/app/(use-header)/codes/_components/view/Page/Card.module.scss
@@ -1,14 +1,10 @@
 .container {
   padding: min(30px, 2.5%) min(50px, 5%);
   border: solid 16px rgb(168, 168, 168); /*線の種類・太さ・色*/
-  box-shadow:
-    // 0px 0px 0px 15px rgba(71, 71, 71, 0.4),
-    5px 5px 10px 15px rgba(153, 153, 153, 0.6);
-
+  box-shadow: 5px 5px 10px 15px rgba(153, 153, 153, 0.6);
   outline: inset 10px rgba(32, 32, 32, 0.5);
   width: 95%;
   max-width: 800px;
-  // border-radius: 10px; /*角の丸み*/
 
   h1 {
     font-size: $font-size-lg;
@@ -46,17 +42,6 @@
       align-items: center;
     }
   }
-
-  // .code_area_box {
-  //   margin: 30px 0;
-  //   border-top: inset 8px rgba(31, 31, 36, 0.75); /*線の種類・太さ・色*/
-  //   border-bottom: inset 8px rgb(31, 31, 36); /*線の種類・太さ・色*/
-  //   border-left: inset 8px rgba(31, 31, 36, 0.75); /*線の種類・太さ・色*/
-  //   border-right: inset 8px rgb(31, 31, 36); /*線の種類・太さ・色*/
-  //   box-shadow:
-  //     0px 0px 0px 12px rgba(71, 71, 71, 0.4),
-  //     5px 5px 10px 12px rgba(153, 153, 153, 0.6);
-  // }
 
   .score_box {
     display: flex;

--- a/src/app/(use-header)/codes/_components/view/Page/Card.module.scss
+++ b/src/app/(use-header)/codes/_components/view/Page/Card.module.scss
@@ -1,9 +1,14 @@
 .container {
-  padding: min(15px, 2.5%) min(50px, 5%);
-  border: solid 1.5px #333; /*線の種類・太さ・色*/
+  padding: min(30px, 2.5%) min(50px, 5%);
+  border: solid 16px rgb(168, 168, 168); /*線の種類・太さ・色*/
+  box-shadow:
+    // 0px 0px 0px 15px rgba(71, 71, 71, 0.4),
+    5px 5px 10px 15px rgba(153, 153, 153, 0.6);
+
+  outline: inset 10px rgba(32, 32, 32, 0.5);
   width: 95%;
   max-width: 800px;
-  border-radius: 10px; /*角の丸み*/
+  // border-radius: 10px; /*角の丸み*/
 
   h1 {
     font-size: $font-size-lg;
@@ -41,6 +46,17 @@
       align-items: center;
     }
   }
+
+  // .code_area_box {
+  //   margin: 30px 0;
+  //   border-top: inset 8px rgba(31, 31, 36, 0.75); /*線の種類・太さ・色*/
+  //   border-bottom: inset 8px rgb(31, 31, 36); /*線の種類・太さ・色*/
+  //   border-left: inset 8px rgba(31, 31, 36, 0.75); /*線の種類・太さ・色*/
+  //   border-right: inset 8px rgb(31, 31, 36); /*線の種類・太さ・色*/
+  //   box-shadow:
+  //     0px 0px 0px 12px rgba(71, 71, 71, 0.4),
+  //     5px 5px 10px 12px rgba(153, 153, 153, 0.6);
+  // }
 
   .score_box {
     display: flex;

--- a/src/app/(use-header)/codes/_components/view/Page/index.module.scss
+++ b/src/app/(use-header)/codes/_components/view/Page/index.module.scss
@@ -1,7 +1,7 @@
 .containers {
-  padding: 50px 0 100px;
+  padding: 70px 0 100px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 25px;
+  gap: 100px;
 }


### PR DESCRIPTION
## 説明

クソコードを表示するカードをリッチに

## 現在の動作 (更新前)

<img width="1731" alt="image" src="https://github.com/user-attachments/assets/d1b09221-f427-42c0-bd75-a8d87391b844">

## 新しい動作 (更新後)

<img width="1731" alt="image" src="https://github.com/user-attachments/assets/b360d83b-e21d-40b1-af46-d8ee713d2340">

## 追加情報

<!-- その他の情報があれば追加してください -->
